### PR TITLE
Object serialization interface changes

### DIFF
--- a/app/src/main/kotlin/com/vinted/preferx/examples/ObjectPreferenceExample.kt
+++ b/app/src/main/kotlin/com/vinted/preferx/examples/ObjectPreferenceExample.kt
@@ -15,15 +15,16 @@ class ObjectPreferenceExample : Activity() {
         getSharedPreferences("app-preferences", Context.MODE_PRIVATE)
     }
 
-    private val serializer by lazy {
-        GsonSerializer(Gson())
+    private val gson by lazy {
+        Gson()
     }
+
 
     private val objectPreference by lazy {
         sharedPreferences.objectPreference(
                 name = "foo",
                 defaultValue = Foo(bar = 0L),
-                serializer = serializer,
+                serializer = GsonSerializer(gson),
                 clazz = Foo::class.java
         )
     }
@@ -51,15 +52,14 @@ class ObjectPreferenceExample : Activity() {
 
     internal data class Foo(val bar: Long)
 
-    internal class GsonSerializer(
+    internal class GsonSerializer<T : Any>(
             private val gson: Gson
-    ) : PreferxSerializer {
-
-        override fun toString(value: Any): String {
-            return gson.toJson(value)
+    ) : PreferxSerializer<T> {
+        override fun toString(value: T, type: Type): String {
+            return gson.toJson(value, type)
         }
 
-        override fun fromString(string: String, type: Type): Any? {
+        override fun fromString(string: String, type: Type): T {
             return gson.fromJson(string, type)
         }
     }

--- a/library/src/main/kotlin/com/vinted/preferx/EntityPrefSerializer.kt
+++ b/library/src/main/kotlin/com/vinted/preferx/EntityPrefSerializer.kt
@@ -4,14 +4,14 @@ import android.content.SharedPreferences
 import java.lang.ref.SoftReference
 
 class EntityPrefSerializer<T : Any>(
-        private val serializer: PreferxSerializer,
+        private val serializer: PreferxSerializer<T>,
         private val clazz: Class<T>
 ) : Serializer<T> {
 
     private var cached: SoftReference<Cache<T>>? = null
 
     override fun serialize(storage: SharedPreferences.Editor, key: String, value: T) {
-        val string = serializer.toString(value)
+        val string = serializer.toString(value, clazz)
         cached = SoftReference(Cache(value, string))
         storage.putString(key, string)
     }
@@ -24,8 +24,8 @@ class EntityPrefSerializer<T : Any>(
         if (cachedValue != null && cachedValue.string == string) return cachedValue.value
         if (string.isEmpty()) return default
 
-        val value = serializer.fromString(string, clazz)!!
-        cached = SoftReference(Cache(value as T, string))
+        val value = serializer.fromString(string, clazz)
+        cached = SoftReference(Cache(value, string))
         return value
     }
 

--- a/library/src/main/kotlin/com/vinted/preferx/ObjectPreferenceImpl.kt
+++ b/library/src/main/kotlin/com/vinted/preferx/ObjectPreferenceImpl.kt
@@ -6,7 +6,7 @@ class ObjectPreferenceImpl<T : Any>(
         prefs: SharedPreferences,
         key: String,
         default: T,
-        serializer: PreferxSerializer,
+        serializer: PreferxSerializer<T>,
         clazz: Class<T>
 ) : BasePreferenceImpl<T>(
         prefs,

--- a/library/src/main/kotlin/com/vinted/preferx/PreferxSerializer.kt
+++ b/library/src/main/kotlin/com/vinted/preferx/PreferxSerializer.kt
@@ -2,7 +2,7 @@ package com.vinted.preferx
 
 import java.lang.reflect.Type
 
-interface PreferxSerializer {
-    fun toString(value: Any): String
-    fun fromString(string: String, type: Type): Any?
+interface PreferxSerializer<T: Any> {
+    fun toString(value: T, type: Type): String
+    fun fromString(string: String, type: Type): T
 }

--- a/library/src/main/kotlin/com/vinted/preferx/extensions.kt
+++ b/library/src/main/kotlin/com/vinted/preferx/extensions.kt
@@ -21,7 +21,7 @@ fun SharedPreferences.longPreference(name: String, defaultValue: Long): LongPref
 fun <T : Any> SharedPreferences.objectPreference(
         name: String,
         defaultValue: T,
-        serializer: PreferxSerializer,
+        serializer: PreferxSerializer<T>,
         clazz: Class<T>
 ): ObjectPreference<T> {
     return ObjectPreferenceImpl(this, name, defaultValue, serializer, clazz)

--- a/library/src/test/java/com/vinted/preferx/EntityPrefSerializerTest.kt
+++ b/library/src/test/java/com/vinted/preferx/EntityPrefSerializerTest.kt
@@ -10,7 +10,7 @@ class EntityPrefSerializerTest {
 
     private val prefs: SharedPreferences = mock()
     private val editor: SharedPreferences.Editor = mock()
-    private val serializer = mock<PreferxSerializer>()
+    private val serializer = mock<PreferxSerializer<Int>>()
     private val value = 1
     private val key = "foo"
 
@@ -18,7 +18,7 @@ class EntityPrefSerializerTest {
 
     @Before
     fun setUp() {
-        whenever(serializer.toString(any()))
+        whenever(serializer.toString(any(), any()))
                 .then {
                     it.arguments[0].toString()
                 }


### PR DESCRIPTION
Changed object serialization interface due to moshi. In old version `toString` called on Moshi would look like:
```kotlin
moshi.adapter<Any?>(Any::class.java).toJson(value)
```

With this new interface Moshi could be integrated:
```kotlin
        override fun fromString(string: String, type: Type): T{
            return moshi.adapter<T>(type).fromJson(string)
        }

        override fun toString(value: Any): String {
            return moshi.adapter<T>(type).toJson(value)
        }
```